### PR TITLE
also install doctr

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ secure key to add. You should also have something like
        secure: "<your secure key from doctr here>"
 
    script:
-     - pip install requests cryptography sphinx doctr
+     - pip install sphinx doctr
      - cd docs
      - make html
      - cd ..

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ secure key to add. You should also have something like
        secure: "<your secure key from doctr here>"
 
    script:
-     - pip install requests cryptography sphinx
+     - pip install requests cryptography sphinx doctr
      - cd docs
      - make html
      - cd ..

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -111,7 +111,7 @@ def configure(args, parser):
         parser.error("doctr appears to be running on Travis. Use "
             "doctr configure --force to run anyway.")
 
-    repo = input("What repo to you want to build the docs for? ")
+    repo = input("What repo do you want to build the docs for? ")
 
     N = IncrementingInt(1)
 
@@ -167,6 +167,7 @@ def configure(args, parser):
         print(dedent("""\
         {N}. Add
 
+            - pip install doctr
             - doctr deploy {options}
 
         to the docs build of your .travis.yml.


### PR DESCRIPTION
For anyone not us, they need to install doctr in the `.travis.yml` file or things will go bonk.

Also, our example `.travis.yml` is doing things with miniconda -- do we want to mention this in the README or just stick with `pip`?    