### PR TITLE
Add installation instructions to the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,23 @@ to GitHub pages.
 This tool is still a work in progress, but once it works it's going to be
 awesome.
 
+Installation
+------------
+
+Install doctr with pip
+
+.. code::
+
+   pip install doctr
+
+or conda
+
+.. code::
+
+   conda install -c conda-forge doctr
+
+**Note that doctr requires Python 3.5.**
+
 Usage
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-Travis docs builder
-===================
+Doctr
+=====
 
 A tool for automatically building Sphinx docs on Travis CI, and deploying them
 to GitHub pages.

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,9 @@ Travis docs builder
 A tool for automatically building Sphinx docs on Travis CI, and deploying them
 to GitHub pages.
 
+Contribute to Doctr development on `GitHub
+<https://github.com/gforsyth/doctr>`_.
+
 Installation
 ------------
 

--- a/README.rst
+++ b/README.rst
@@ -4,9 +4,6 @@ Travis docs builder
 A tool for automatically building Sphinx docs on Travis CI, and deploying them
 to GitHub pages.
 
-This tool is still a work in progress, but once it works it's going to be
-awesome.
-
 Installation
 ------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,8 +11,8 @@
    alt="Fork me on GitHub"
    data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"></a>
 
-Welcome to Doctr documentation!
-===============================
+Welcome to the Doctr documentation!
+===================================
 
 .. include:: ../README.rst
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,6 +3,14 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+.. raw:: html
+
+   <a href="https://github.com/gforsyth/doctr"><img style="position: absolute;
+   top: 0; right: 0; border: 0;"
+   src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67"
+   alt="Fork me on GitHub"
+   data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"></a>
+
 Welcome to Travis docs builder's documentation!
 ===============================================
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-.. Travis docs builder documentation master file, created by
+.. Doctr documentation master file, created by
    sphinx-quickstart on Sun Jul 17 15:34:54 2016.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
@@ -11,8 +11,8 @@
    alt="Fork me on GitHub"
    data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"></a>
 
-Welcome to Travis docs builder's documentation!
-===============================================
+Welcome to Doctr documentation!
+===============================
 
 .. include:: ../README.rst
 

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -160,7 +160,7 @@ def setup_GitHub_push(repo, auth_type='deploy_key', full_key_path='github_deploy
 
     print("Setting git attributes")
     # Should we add some user.email?
-    run(['git', 'config', '--global', 'user.name', "Travis docs builder (Travis CI)"])
+    run(['git', 'config', '--global', 'user.name', "Doctr (Travis CI)"])
 
     print("Adding doctr remote")
     if auth_type == 'token':


### PR DESCRIPTION
Merge as soon as the conda-forge feedstock is created and the package is built. 