### PR TITLE
Use the Sphinx theme options for the GitHub banner

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -123,7 +123,12 @@ html_theme = 'alabaster'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+html_theme_options = {
+    'github_user': 'gforsyth',
+    'github_repo': 'doctr',
+    'github_banner': True,
+    'logo_name': True,
+    }
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,14 +3,6 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-.. raw:: html
-
-   <a href="https://github.com/gforsyth/doctr"><img style="position: absolute;
-   top: 0; right: 0; border: 0;"
-   src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67"
-   alt="Fork me on GitHub"
-   data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"></a>
-
 Welcome to the Doctr documentation!
 ===================================
 


### PR DESCRIPTION
This makes it appear on every page.