### PR TITLE
Update changelog for upcoming 1.2 release

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,7 +9,7 @@ Major Changes
 -------------
 - Allow ``--gh-pages-docs .`` (deploying to the root directory of the
   ``gh-pages`` branch). (#73)
-- Allow deploying to a separate repo (via ``doctr deploy --deploy-repo``). (#63)
+- Allow deploying to a separate repo (via ``doctr deploy --deploy-repo <repo>``). (#63)
 - Automatically detect Sphinx build directory. (#6)
 - Add ``--no-require-master`` flag to allow pushing from branches other than master. (#70)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,7 +7,8 @@
 
 Major Changes
 -------------
-- Allow --gh-pages-docs to be ``.`` (the root directory). (#73)
+- Allow ``--gh-pages-docs .`` (deploying to the root directory of the
+  ``gh-pages`` branch). (#73)
 - Allow deploying to a separate repo (via ``doctr deploy --deploy-repo``). (#63)
 - Automatically detect Sphinx build directory. (#6)
 - Add ``--no-require-master`` flag to allow pushing from branches other than master. (#70)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,14 +2,20 @@
  Doctr Changelog
 =================
 
-1.1.2 (????-??-??)
-==================
+1.2 (????-??-??)
+================
+
+Major Changes
+-------------
+- Allow --gh-pages-docs to be ``.`` (the root directory). (#73)
+- Allow deploying to a separate repo (via ``doctr deploy --deploy-repo``). (#63)
+- Automatically detect Sphinx build directory. (#6)
+- Add ``--no-require-master`` flag to allow pushing from branches other than master. (#70)
 
 Minor Changes
 -------------
-
-- Automatically detect Sphinx build directory (#6)
-- Add ``--no-require-master`` flag to allow pushing from branches other than master (#70)
+- Add a GitHub banner to the docs. (#64)
+- Move to the GitHub organization `drdoctr <https://github.com/drdoctr>`_. (#67)
 
 1.1.1 (2016-08-09)
 ==================


### PR DESCRIPTION
I think it should be 1.2 instead of 1.1.2, as there have been several major
changes.

I have also added the org moving to the changelog
(https://github.com/gforsyth/doctr/issues/67), since I'm assuming that will
happen soon (a PR will be needed; several places in the code reference
"gforsyth", and we'll probably need a new encrypted deploy key).